### PR TITLE
Update module path to `github.com/novelgitllc/ansicolor/v2`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/novelgitllc/ansicolor
+module github.com/novelgitllc/ansicolor/v2
 
 go 1.21


### PR DESCRIPTION
Updated the `go.mod` file to use the correct module path `github.com/novelgitllc/ansicolor/v2`. This ensures proper version management for consumers of the module.